### PR TITLE
Ensure Farcaster init only inside miniapp

### DIFF
--- a/app/post/[author]/[permlink]/page.tsx
+++ b/app/post/[author]/[permlink]/page.tsx
@@ -176,7 +176,12 @@ export async function generateMetadata({
       bannerImage = imageUrls[0];
     }
 
-    const postUrl = `${DOMAIN_URL}/post/${cleanedAuthor}/${permlink}`;
+    if (typeof permlink !== "string") {
+      console.error("generateMetadata: non-string permlink when building URL", permlink);
+    }
+    const permlinkStr = typeof permlink === "string" ? permlink : String(permlink);
+
+    const postUrl = `${DOMAIN_URL}/post/${cleanedAuthor}/${permlinkStr}`;
 
     console.log("Generated metadata:", {
       title,

--- a/hooks/init-frame-sdk.ts
+++ b/hooks/init-frame-sdk.ts
@@ -6,7 +6,13 @@ import sdk from '@farcaster/frame-sdk';
 const InitFrameSDK = () => {
     useEffect(() => {
         const load = async () => {
-            await sdk.actions.ready();
+            try {
+                if (await sdk.isInMiniApp()) {
+                    await sdk.actions.ready();
+                }
+            } catch (error) {
+                console.error("Failed to initialize Farcaster Frame SDK", error);
+            }
         };
 
         load();


### PR DESCRIPTION
## Summary
- check Farcaster Miniapp status before calling `ready`
- validate permlink as a string when building URLs

## Testing
- `pnpm lint`
- `pnpm dev` *(terminated after manual request)*

------
https://chatgpt.com/codex/tasks/task_e_6858264a163c8325acbd13c17b82727a